### PR TITLE
download link with text break

### DIFF
--- a/bootstrap-theme-leihs-mobile/scss/components.scss
+++ b/bootstrap-theme-leihs-mobile/scss/components.scss
@@ -123,15 +123,3 @@
     padding-left: 4.25rem;
   }
 }
-
-/* Component: DownloadLink */
-
-.download-link {
-  display: inline-block;
-  padding-left: 1.5rem;
-  text-indent: -1.5rem;
-  &__icon {
-    margin-right: 0.5rem;
-    margin-top: -0.2rem;
-  }
-}

--- a/src/components/MobileApp/DesignComponents/DownloadLink.js
+++ b/src/components/MobileApp/DesignComponents/DownloadLink.js
@@ -3,11 +3,11 @@ import cx from 'classnames'
 import Icon, { iconDownload } from './Icons'
 
 export default function DownloadLink({ children, href, className, ...restProps }) {
-  const linkProps = { href, className: cx('download-link', className), ...restProps }
+  const linkProps = { href, className: cx('d-flex', className), ...restProps }
   return (
     <a {...linkProps}>
-      <Icon icon={iconDownload} className="download-link__icon" />
-      {children}
+      <Icon icon={iconDownload} style={{ marginRight: '10px', marginTop: '2px', flex: '16px 0 0' }} />
+      <div>{children}</div>
     </a>
   )
 }

--- a/src/components/MobileApp/DesignComponents/DownloadLink.stories.js
+++ b/src/components/MobileApp/DesignComponents/DownloadLink.stories.js
@@ -63,10 +63,10 @@ export const wrap = ({ onClick }) => {
       <div className="p-3 shadow" style={{ width: '14rem' }}>
         <Stack space="3">
           <DownloadLink onClick={handleClick} href="some/route">
-            QX1204USB_Q1204USB_QSG.pdf
+            <span className="text-break">QX1204USB_Q1204USB_QSG.pdf</span>
           </DownloadLink>
           <DownloadLink onClick={handleClick} href="some/route">
-            Download the specification
+            <span className="text-break">Download the specification</span>
           </DownloadLink>
         </Stack>
       </div>

--- a/src/tests/__snapshots__/storybook-snapshots.test.js.snap
+++ b/src/tests/__snapshots__/storybook-snapshots.test.js.snap
@@ -22576,21 +22576,25 @@ exports[`Storybook HTML Snapshots MobileApp/Design Components/Content/DownloadLi
   </p>
   <p>
     <a
-      className="download-link"
+      className="d-flex"
       href="some/route"
       onClick={[Function]}
     >
       <svg
-        className="download-link__icon"
         style={
           Object {
             "display": "inline",
+            "flex": "16px 0 0",
+            "marginRight": "10px",
+            "marginTop": "2px",
           }
         }
       >
         Download Icon.svg
       </svg>
-      Download the specification
+      <div>
+        Download the specification
+      </div>
     </a>
   </p>
   <p
@@ -22620,63 +22624,75 @@ exports[`Storybook HTML Snapshots MobileApp/Design Components/Content/DownloadLi
     className="mb-3"
   >
     <a
-      className="download-link"
+      className="d-flex"
       href="some/route"
       onClick={[Function]}
     >
       <svg
-        className="download-link__icon"
         style={
           Object {
             "display": "inline",
+            "flex": "16px 0 0",
+            "marginRight": "10px",
+            "marginTop": "2px",
           }
         }
       >
         Download Icon.svg
       </svg>
-      QX1204USB_Q1204USB_QSG.pdf
+      <div>
+        QX1204USB_Q1204USB_QSG.pdf
+      </div>
     </a>
   </div>
   <div
     className="mb-3"
   >
     <a
-      className="download-link"
+      className="d-flex"
       href="some/route"
       onClick={[Function]}
     >
       <svg
-        className="download-link__icon"
         style={
           Object {
             "display": "inline",
+            "flex": "16px 0 0",
+            "marginRight": "10px",
+            "marginTop": "2px",
           }
         }
       >
         Download Icon.svg
       </svg>
-      QX1204USB_Q1204USB_Manual.pdf
+      <div>
+        QX1204USB_Q1204USB_Manual.pdf
+      </div>
     </a>
   </div>
   <div
     className="mb-3"
   >
     <a
-      className="download-link"
+      className="d-flex"
       href="some/route"
       onClick={[Function]}
     >
       <svg
-        className="download-link__icon"
         style={
           Object {
             "display": "inline",
+            "flex": "16px 0 0",
+            "marginRight": "10px",
+            "marginTop": "2px",
           }
         }
       >
         Download Icon.svg
       </svg>
-      QX1204USB_Q1204USB_Specs.pdf
+      <div>
+        QX1204USB_Q1204USB_Specs.pdf
+      </div>
     </a>
   </div>
 </div>
@@ -22693,21 +22709,25 @@ exports[`Storybook HTML Snapshots MobileApp/Design Components/Content/DownloadLi
     Set arbitrary attributes with restProps
   </p>
   <a
-    className="download-link text-primary"
+    className="d-flex text-primary"
     href="some/route"
     onClick={[Function]}
   >
     <svg
-      className="download-link__icon"
       style={
         Object {
           "display": "inline",
+          "flex": "16px 0 0",
+          "marginRight": "10px",
+          "marginTop": "2px",
         }
       }
     >
       Download Icon.svg
     </svg>
-    Download the Specification
+    <div>
+      Download the Specification
+    </div>
   </a>
 </div>
 `;
@@ -22734,42 +22754,58 @@ exports[`Storybook HTML Snapshots MobileApp/Design Components/Content/DownloadLi
       className="mb-3"
     >
       <a
-        className="download-link"
+        className="d-flex"
         href="some/route"
         onClick={[Function]}
       >
         <svg
-          className="download-link__icon"
           style={
             Object {
               "display": "inline",
+              "flex": "16px 0 0",
+              "marginRight": "10px",
+              "marginTop": "2px",
             }
           }
         >
           Download Icon.svg
         </svg>
-        QX1204USB_Q1204USB_QSG.pdf
+        <div>
+          <span
+            className="text-break"
+          >
+            QX1204USB_Q1204USB_QSG.pdf
+          </span>
+        </div>
       </a>
     </div>
     <div
       className="mb-3"
     >
       <a
-        className="download-link"
+        className="d-flex"
         href="some/route"
         onClick={[Function]}
       >
         <svg
-          className="download-link__icon"
           style={
             Object {
               "display": "inline",
+              "flex": "16px 0 0",
+              "marginRight": "10px",
+              "marginTop": "2px",
             }
           }
         >
           Download Icon.svg
         </svg>
-        Download the specification
+        <div>
+          <span
+            className="text-break"
+          >
+            Download the specification
+          </span>
+        </div>
       </a>
     </div>
   </div>


### PR DESCRIPTION
needs fix: first line is empty when text breaks???
http://localhost:9009/?path=/story/mobileapp-design-components-content-downloadlink--wrap

current wrapping without breaking long words:
<img width="1132" alt="Screen Shot 2021-08-18 at 11 33 23" src="https://user-images.githubusercontent.com/134942/129874938-873a42fe-fce0-48f7-8759-32c8e1f189da.png">



problem when using `<span className="text-break">`:

<img width="1138" alt="Screen Shot 2021-08-18 at 11 32 30" src="https://user-images.githubusercontent.com/134942/129874818-8836f55a-6e43-4eb8-9d24-0c8cfa6262ef.png">
