### PR TITLE
Experimental: enable display of loading state in Order calendar

### DIFF
--- a/src/components/MobileApp/DesignComponents/DateRangePicker.js
+++ b/src/components/MobileApp/DesignComponents/DateRangePicker.js
@@ -61,7 +61,15 @@ export default function DateRangePicker({
   }
 
   // loading state
-  const isLoading = maxDateLoaded && endOfMonth(maxDateLoaded) < endOfMonth(shownDate)
+  const [isLoading, setIsLoading] = useState(false)
+  useEffect(() => {
+    setIsLoading(maxDateLoaded && endOfMonth(maxDateLoaded) < endOfMonth(shownDate))
+  }, [maxDateLoaded, shownDate])
+
+  function handleShownDateChange(d) {
+    setIsLoading(maxDateLoaded && endOfMonth(maxDateLoaded) < endOfMonth(d))
+    onShownDateChange(d)
+  }
 
   // satellite inputs
 
@@ -160,7 +168,7 @@ export default function DateRangePicker({
           shownDate={shownDate}
           focusedRange={focusedRange}
           onRangeFocusChange={handleRangeFocusChange}
-          onShownDateChange={onShownDateChange}
+          onShownDateChange={handleShownDateChange}
           maxDateLoaded={maxDateLoaded}
           loadingIndicator={<div>LOADING...</div>}
           // date constraints:


### PR DESCRIPTION
Current problem: the loading state (semi-transparent days) would appear when `endOfMonth(maxDateLoaded) < endOfMonth(shownDate)`. However the CLJS component does not update `shownDate` immediately after the `onShownDateChange` is emitted by `OrderPanel`, but only after the data was loaded, so the loading state is never rendered. 

The question is: should the CLJS update `shownDate` immediately?

Or is the JS component responsible to update its own state before emitting the event? If so, the change in this pull request is a possible solution, but with some question marks...

Or are there other / better solutions?  